### PR TITLE
Split posts into Articles and Week Notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+---
+name: CI
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gem "jekyll"
 gem "rake"
 gem "redcarpet"
+
+group :test do
+  gem "rspec"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.4)
+    diff-lcs (1.4.4)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -47,6 +48,19 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.4.0)
     rouge (3.3.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.7.3)
@@ -62,6 +76,7 @@ DEPENDENCIES
   jekyll
   rake
   redcarpet
+  rspec
 
 BUNDLED WITH
    1.17.2

--- a/_plugins/filter_posts.rb
+++ b/_plugins/filter_posts.rb
@@ -1,0 +1,22 @@
+module Jekyll
+  module FilterPosts
+    def filter_posts(posts, attribute, expression)
+      method_name, key = expression.scan(/(\w*)\s?'([\w-]*)?'/).first
+
+      method = case method_name
+               when "includes"
+                 :select
+               when "excludes"
+                 :reject
+               else
+                 nil
+               end
+
+      return [] unless method
+
+      posts.send(method) { |post| post.data[attribute].include?(key) }
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::FilterPosts)

--- a/index.html
+++ b/index.html
@@ -13,12 +13,25 @@ layout: default
     This is the place where I write up what I learn.
   </p>
 
+  <h2>Week Notes</h2>
+
+  <ul>
+    {% assign week_notes = site.posts | filter_posts: "tags", "includes 'week-notes'" %}
+    {% for post in week_notes limit:5 %}
+      <li>
+      <a href="{{ post.url }}">{{ post.title }}</a> &mdash; <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_long_string: "ordinal" }}</time>
+    </li>
+
+    {% endfor %}
+  </ul>
+
   <h2>Articles</h2>
 
   <ul>
-    {% for post in site.posts limit:5 %}
+    {% assign posts = site.posts | filter_posts: "tags", "excludes 'week-notes'" %}
+    {% for post in posts limit:5 %}
     <li>
-      <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a> &mdash; <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+      <a href="{{ post.url }}">{{ post.title }}</a> &mdash; <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_long_string: "ordinal" }}</time>
     </li>
     {% endfor %}
   </ul>

--- a/spec/filter_posts_spec.rb
+++ b/spec/filter_posts_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+require_relative "../_plugins/filter_posts"
+
+RSpec.describe Jekyll::FilterPosts do
+  include Jekyll::FilterPosts
+
+  describe "tags" do
+    it "can filter by presence of tags" do
+      document1 = double("Jekyll::Document", title: "Post 1",
+                                             data: { "tags" => ["week-notes"] })
+      document2 = double("Jekyll::Document", title: "Post 2",
+                                             data: { "tags" => ["projects"] })
+
+      posts = filter_posts([document1, document2],
+                           "tags",
+                           "includes 'week-notes'")
+
+      expect(posts).to match_array([document1])
+    end
+
+    it "can filter by exclusion of tags" do
+      document1 = double("Jekyll::Document", title: "Post 1",
+                                             data: { "tags" => ["week-notes"] })
+      document2 = double("Jekyll::Document", title: "Post 2",
+                                             data: { "tags" => ["projects"] })
+
+      posts = filter_posts([document1, document2],
+                           "tags",
+                           "excludes 'week-notes'")
+
+      expect(posts).to match_array([document2])
+    end
+
+    it "is empty if the filter method is invalid" do
+      document1 = double("Jekyll::Document", title: "Post 1",
+                                             data: { "tags" => ["week-notes"] })
+      document2 = double("Jekyll::Document", title: "Post 2",
+                                             data: { "tags" => ["projects"] })
+
+      posts = filter_posts([document1, document2],
+                           "tags",
+                           "something 'week-notes'")
+
+      expect(posts).to match_array([])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require "rspec"
+
+require "jekyll"


### PR DESCRIPTION
This commit introduces a new Jekyll filter, which allows us to take the
global `site.posts` collection and include or exclude certain tags.

This is needed as the included `where_exp` filter doesn't allow you to
negate collection contents and isn't being implemented.

https://github.com/Shopify/liquid/issues/138